### PR TITLE
Update CLI scripts

### DIFF
--- a/tools/rcli.py
+++ b/tools/rcli.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python3
-"""Simple Python client for rjsonsrv."""
-import sys
-import json
-import requests
+import argparse, json, os, requests, sys
 
-if len(sys.argv) < 2:
-    print("Usage: rcli.py CODE [PORT]", file=sys.stderr)
-    sys.exit(1)
+CFG   = os.path.expanduser('~/.rjson/instances')
+PORTS = {l.split(':')[0]: int(l.split(':')[1]) for l in open(CFG)} if os.path.exists(CFG) else {}
 
-code = sys.argv[1]
-port = int(sys.argv[2]) if len(sys.argv) > 2 else 8080
-url = f"http://127.0.0.1:{port}/execute"
-resp = requests.post(url, json={"command": code})
-print(resp.text)
+def port(label): return PORTS.get(label, int(label))
+
+def main():
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest='cmd')
+
+    e = sub.add_parser('exec');  e.add_argument('label'); e.add_argument('code', nargs='?')
+    s = sub.add_parser('status');s.add_argument('label')
+
+    args = p.parse_args()
+    if args.cmd == 'exec':
+        code = args.code or sys.stdin.read()
+        r = requests.post(f'http://127.0.0.1:{port(args.label)}/execute',
+                          json={'command': code})
+        print(json.dumps(r.json(), indent=2))
+    elif args.cmd == 'status':
+        r = requests.get(f'http://127.0.0.1:{port(args.label)}/status')
+        print(json.dumps(r.json(), indent=2))
+
+if __name__ == '__main__':
+    main()

--- a/tools/rcli.sh
+++ b/tools/rcli.sh
@@ -1,11 +1,73 @@
 #!/usr/bin/env bash
-# Simple shell client for rjsonsrv
-PORT=${1:-8080}
-shift || true
-CODE="$@"
-if [ -z "$CODE" ]; then
-  echo "Usage: rcli.sh [PORT] CODE" >&2
-  exit 1
-fi
-curl -s -X POST -H "Content-Type: application/json" \
-  -d "{\"command\": \"$CODE\"}" "http://127.0.0.1:$PORT/execute"
+#
+# Very small CLI for the R JSON server described earlier.
+
+CONFIG_DIR="${HOME}/.rjson"
+INST_FILE="${CONFIG_DIR}/instances"
+DEFAULT_PORT=8080
+
+mkdir -p "${CONFIG_DIR}"
+touch  "${INST_FILE}"
+
+# ----------------------------------------------------------
+# Helper: lookup port from label (else treat as raw port)
+port_of() {
+  local label=$1
+  local line
+  line=$(grep "^${label}:" "${INST_FILE}" 2>/dev/null)
+  if [[ -n $line ]]; then
+    cut -d':' -f2 <<<"$line"
+  else
+    echo "$label"
+  fi
+}
+
+case "$1" in
+  start)
+    label=${2:-default}
+    port=${3:-$DEFAULT_PORT}
+    Rscript r_json_server.R --background --port "$port" &
+    pid=$!
+    echo "${label}:${port}:${pid}" >> "${INST_FILE}"
+    echo "Started '${label}' on port ${port} (PID ${pid})"
+    ;;
+
+  stop)
+    label=${2:-default}
+    port=$(port_of "$label")
+    curl -s -X POST "http://127.0.0.1:${port}/shutdown" >/dev/null
+    sed -i.bak "/^${label}:/d" "${INST_FILE}"
+    echo "Sent shutdown to '${label}' (port ${port})"
+    ;;
+
+  status)
+    label=${2:-default}
+    port=$(port_of "$label")
+    curl -s "http://127.0.0.1:${port}/status" | jq
+    ;;
+
+  exec)
+    label=${2:-default}
+    port=$(port_of "$label")
+    code=""
+    if [[ -t 0 ]] && [[ -z $3 ]]; then
+      echo "Nothing to run; supply code with -e or pipe via stdin" >&2
+      exit 1
+    fi
+    while [[ $# -gt 2 ]]; do shift; [[ $1 == -e ]] && { code="$2"; shift; } done
+    [[ -z $code ]] && code=$(cat)       # read piped input
+    curl -s -X POST -H "Content-Type: application/json" \
+         -d "{\"command\":$(jq -Rs . <<<"$code")}" \
+         "http://127.0.0.1:${port}/execute" | jq
+    ;;
+
+  list)
+    cat "${INST_FILE}"
+    ;;
+
+  *)
+    cat <<EOF
+Usage: rcli.sh {start [label] [port]|stop [label]|status [label]|exec [label] -e CODE|exec [label] < script.R|list}
+EOF
+    ;;
+esac


### PR DESCRIPTION
## Summary
- overhaul Bash and Python clients for rjson server
- maintain port label registry and add exec/status functionality
- support listing and controlling server instances
- add JSON pretty-printing

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_685317f40ed88326b654f5e92c7e4f20