### PR TITLE
Implement output configuration controls

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -1,11 +1,24 @@
-exec_code <- function(code, port = 8080) {
-  url <- sprintf("http://127.0.0.1:%d/execute", as.integer(port))
+exec_code <- function(code, port = 8080, plain = FALSE, summary = TRUE,
+                      output = TRUE, warnings = TRUE, error = TRUE) {
+  query <- list()
+  if (plain) query$format <- "text"
+  if (!summary) query$summary <- "false"
+  if (!output) query$output <- "false"
+  if (!warnings) query$warnings <- "false"
+  if (!error) query$error <- "false"
+  qs <- if (length(query) > 0)
+    paste0("?", paste(names(query), query, sep = "=", collapse = "&")) else ""
+  url <- sprintf("http://127.0.0.1:%d/execute%s", as.integer(port), qs)
   res <- httr::POST(
     url,
     body = jsonlite::toJSON(list(command = code), auto_unbox = TRUE),
     encode = "json"
   )
-  jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8"), simplifyVector = FALSE)
+  if (plain) {
+    httr::content(res, as = "text", encoding = "UTF-8")
+  } else {
+    jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8"), simplifyVector = FALSE)
+  }
 }
 
 server_status <- function(port = 8080) {

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -6,3 +6,21 @@ test_that("round-trip code returns expected result", {
   res <- rjsonsrv::exec_code("1+1", port=8123)
   expect_equal(res$result_summary$type, "double")
 })
+
+test_that("plain text mode works", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "r_json_server.R", package="rjsonsrv"), "--port", 8124, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- rjsonsrv::exec_code("1+1", port=8124, plain = TRUE)
+  expect_match(res, "2")
+})
+
+test_that("warnings can be suppressed", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "r_json_server.R", package="rjsonsrv"), "--port", 8125, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- rjsonsrv::exec_code("warning('a'); 1", port=8125, warnings = FALSE)
+  expect_false("warning" %in% names(res))
+})


### PR DESCRIPTION
## Summary
- extend `exec_code()` to support plain text responses and new query params
- implement query parsing and plain text mode in the server
- allow toggling warnings, errors, and output fields
- test plain text mode and warning suppression

## Testing
- `micromamba run -n myr R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_6853189b21848326b5ec73a575b168dd