### PR TITLE
Add cross-platform CLI scripts

### DIFF
--- a/tools/rcli.ps1
+++ b/tools/rcli.ps1
@@ -1,10 +1,74 @@
-param(
-  [string]$Code,
-  [int]$Port = 8080
-)
-if (-not $Code) {
-  Write-Error "Usage: rcli.ps1 -Code <code> [-Port <port>]"
-  exit 1
+$ErrorActionPreference = 'Stop'
+$configDir = Join-Path $HOME '.rjson'
+$instFile  = Join-Path $configDir 'instances'
+$defaultPort = 8080
+
+if (!(Test-Path $configDir)) { New-Item -ItemType Directory -Path $configDir | Out-Null }
+if (!(Test-Path $instFile)) { New-Item -ItemType File -Path $instFile | Out-Null }
+
+function Load-Instances {
+    $inst = @{}
+    if (Test-Path $instFile) {
+        Get-Content $instFile | ForEach-Object {
+            $parts = $_ -split ':'
+            $inst[$parts[0]] = @{ port = [int]$parts[1]; pid = [int]$parts[2] }
+        }
+    }
+    return $inst
 }
-$Body = @{ command = $Code } | ConvertTo-Json
-Invoke-RestMethod -Uri "http://127.0.0.1:$Port/execute" -Method Post -Body $Body -ContentType 'application/json'
+
+function Save-Instances($inst) {
+    $inst.GetEnumerator() | ForEach-Object {
+        "$($_.Key):$($inst[$_.Key].port):$($inst[$_.Key].pid)"
+    } | Set-Content $instFile
+}
+
+function Port-Of($label, $inst) {
+    if ($inst.ContainsKey($label)) { return $inst[$label].port }
+    return [int]$label
+}
+
+$cmd = if ($args.Count) { $args[0] } else { '' }
+$inst = Load-Instances
+
+switch ($cmd) {
+    'start' {
+        $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
+        $port  = if ($args.Length -gt 2) { [int]$args[2] } else { $defaultPort }
+        $proc = Start-Process -PassThru Rscript -ArgumentList 'r_json_server.R','--background','--port',$port
+        $inst[$label] = @{ port = $port; pid = $proc.Id }
+        Save-Instances $inst
+        Write-Output "Started '$label' on port $port (PID $($proc.Id))"
+    }
+    'stop' {
+        $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
+        $port = Port-Of $label $inst
+        Invoke-RestMethod -Uri "http://127.0.0.1:$port/shutdown" -Method Post > $null
+        if ($inst.ContainsKey($label)) { $inst.Remove($label); Save-Instances $inst }
+        Write-Output "Sent shutdown to '$label' (port $port)"
+    }
+    'status' {
+        $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
+        $port = Port-Of $label $inst
+        Invoke-RestMethod -Uri "http://127.0.0.1:$port/status" | ConvertTo-Json -Depth 10
+    }
+    'exec' {
+        $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
+        $code = $null
+        $i = 2
+        while ($i -lt $args.Count) {
+            if ($args[$i] -eq '-e') { $code = $args[$i+1]; $i += 2 } else { $i++ }
+        }
+        if (-not $code) { $code = [Console]::In.ReadToEnd() }
+        if (-not $code) { Write-Error 'Nothing to run; supply code with -e or pipe via stdin'; exit 1 }
+        $port = Port-Of $label $inst
+        $body = @{ command = $code } | ConvertTo-Json
+        Invoke-RestMethod -Uri "http://127.0.0.1:$port/execute" -Method Post -Body $body -ContentType 'application/json' | ConvertTo-Json -Depth 10
+    }
+    'list' {
+        Get-Content $instFile
+    }
+    default {
+        Write-Output "Usage: rcli.ps1 {start [label] [port]|stop [label]|status [label]|exec [label] -e CODE|exec [label] < script.R|list}"
+    }
+}

--- a/tools/rcli.py
+++ b/tools/rcli.py
@@ -1,27 +1,131 @@
 #!/usr/bin/env python3
-import argparse, json, os, requests, sys
+"""Simple cross-platform CLI for r_json_server."""
 
-CFG   = os.path.expanduser('~/.rjson/instances')
-PORTS = {l.split(':')[0]: int(l.split(':')[1]) for l in open(CFG)} if os.path.exists(CFG) else {}
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Dict, Tuple
 
-def port(label): return PORTS.get(label, int(label))
+import requests
 
-def main():
-    p = argparse.ArgumentParser()
-    sub = p.add_subparsers(dest='cmd')
+CONFIG_DIR = os.path.expanduser("~/.rjson")
+INST_FILE = os.path.join(CONFIG_DIR, "instances")
+DEFAULT_PORT = 8080
 
-    e = sub.add_parser('exec');  e.add_argument('label'); e.add_argument('code', nargs='?')
-    s = sub.add_parser('status');s.add_argument('label')
 
-    args = p.parse_args()
-    if args.cmd == 'exec':
-        code = args.code or sys.stdin.read()
-        r = requests.post(f'http://127.0.0.1:{port(args.label)}/execute',
-                          json={'command': code})
-        print(json.dumps(r.json(), indent=2))
-    elif args.cmd == 'status':
-        r = requests.get(f'http://127.0.0.1:{port(args.label)}/status')
-        print(json.dumps(r.json(), indent=2))
+def load_instances() -> Dict[str, Tuple[int, int]]:
+    instances: Dict[str, Tuple[int, int]] = {}
+    if os.path.exists(INST_FILE):
+        with open(INST_FILE) as fh:
+            for line in fh:
+                label, port, pid = line.strip().split(":")
+                instances[label] = (int(port), int(pid))
+    return instances
 
-if __name__ == '__main__':
+
+def save_instances(instances: Dict[str, Tuple[int, int]]) -> None:
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with open(INST_FILE, "w") as fh:
+        for label, (port, pid) in instances.items():
+            fh.write(f"{label}:{port}:{pid}\n")
+
+
+def port_of(label: str, instances: Dict[str, Tuple[int, int]]) -> int:
+    """Return the port associated with *label* or treat *label* as a port."""
+    return instances[label][0] if label in instances else int(label)
+
+
+def start(label: str, port: int) -> None:
+    inst = load_instances()
+    proc = subprocess.Popen([
+        "Rscript",
+        "r_json_server.R",
+        "--background",
+        "--port",
+        str(port),
+    ])
+    inst[label] = (port, proc.pid)
+    save_instances(inst)
+    print(f"Started '{label}' on port {port} (PID {proc.pid})")
+
+
+def stop(label: str) -> None:
+    inst = load_instances()
+    port = port_of(label, inst)
+    try:
+        requests.post(f"http://127.0.0.1:{port}/shutdown")
+    finally:
+        if label in inst:
+            inst.pop(label)
+            save_instances(inst)
+    print(f"Sent shutdown to '{label}' (port {port})")
+
+
+def status(label: str) -> None:
+    inst = load_instances()
+    port = port_of(label, inst)
+    r = requests.get(f"http://127.0.0.1:{port}/status")
+    print(json.dumps(r.json(), indent=2))
+
+
+def exec_code(label: str, code: str | None) -> None:
+    inst = load_instances()
+    port = port_of(label, inst)
+    if not code:
+        code = sys.stdin.read()
+        if not code.strip():
+            print("Nothing to run; supply code with -e or pipe via stdin", file=sys.stderr)
+            sys.exit(1)
+    r = requests.post(
+        f"http://127.0.0.1:{port}/execute",
+        json={"command": code},
+    )
+    print(json.dumps(r.json(), indent=2))
+
+
+def list_instances() -> None:
+    inst = load_instances()
+    for label, (port, pid) in inst.items():
+        print(f"{label}:{port}:{pid}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+
+    sp = sub.add_parser("start")
+    sp.add_argument("label", nargs="?", default="default")
+    sp.add_argument("port", nargs="?", type=int, default=DEFAULT_PORT)
+
+    stop_p = sub.add_parser("stop")
+    stop_p.add_argument("label", nargs="?", default="default")
+
+    status_p = sub.add_parser("status")
+    status_p.add_argument("label", nargs="?", default="default")
+
+    exec_p = sub.add_parser("exec")
+    exec_p.add_argument("label", nargs="?", default="default")
+    exec_p.add_argument("-e", dest="code")
+
+    sub.add_parser("list")
+
+    args = parser.parse_args()
+
+    if args.cmd == "start":
+        start(args.label, args.port)
+    elif args.cmd == "stop":
+        stop(args.label)
+    elif args.cmd == "status":
+        status(args.label)
+    elif args.cmd == "exec":
+        exec_code(args.label, args.code)
+    elif args.cmd == "list":
+        list_instances()
+    else:
+        parser.print_usage()
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- implement full CLI in `rcli.py`
- extend PowerShell helper to support start/stop/status/exec/list

## Testing
- `R -q -e 'devtools::test()'`


------
https://chatgpt.com/codex/tasks/task_e_68531dda050c8326ae2bb6f5694c4a5e