### PR TITLE
Update CLI vignette

### DIFF
--- a/vignettes/bash-cli.Rmd
+++ b/vignettes/bash-cli.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 
 # Overview
 
-The package includes a Bash script, `clir.sh`, for managing a JSON server from the command line. This vignette demonstrates common tasks such as starting the server, running code and stopping it.
+The package includes a Bash script, `clir.sh`, for managing a JSON server from the command line. It relies on the `jq` utility for pretty-printing JSON responses. This vignette demonstrates common tasks such as starting the server, running code and stopping it.
 
 ## Starting a server
 
@@ -38,6 +38,18 @@ $ echo 'sqrt(144)' | tools/clir.sh exec demo
   "plots": "",
   "result_summary": {"type": "double"}
 }
+```
+
+For quick commands you can supply the code directly using `-e`:
+
+```bash
+$ tools/clir.sh exec demo -e '1 + 1'
+```
+
+You can also pipe a script file into `exec`:
+
+```bash
+$ tools/clir.sh exec demo < script.R
 ```
 
 ## Checking status


### PR DESCRIPTION
## Summary
- mention jq dependency in CLI vignette
- document `-e` and file input options for `exec`

## Testing
- `micromamba run -n myr R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_68532752155083268a077c94ad43407b