### PR TITLE
Handle message capture on error

### DIFF
--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -115,7 +115,7 @@ capture_output <- function(expr) {
       }
     }, error = function(e) {
       sink(error_conn, type = "message")
-      cat("Error: ", conditionMessage(e), "\n")
+      message("Error: ", conditionMessage(e))
       sink(NULL, type = "message")
     }),
     warning = function(w) {

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -24,3 +24,13 @@ test_that("warnings can be suppressed", {
   res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE)
   expect_false("warning" %in% names(res))
 })
+
+test_that("errors are captured correctly", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8126, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- replr::exec_code("log('foo')", port=8126)
+  expect_equal(res$output, "")
+  expect_match(res$error, "non-numeric")
+})


### PR DESCRIPTION
## Summary
- use `message()` for writing error text to the message sink
- test that errors return text in `res$error` and no output

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_68532f7038dc83269658c3ba816cf3ae