### PR TITLE
Fix recorded plot detection in replr server

### DIFF
--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -105,10 +105,11 @@ capture_output <- function(expr) {
   withCallingHandlers(
     tryCatch({
       temp_result <- eval(parse(text = expr), envir = .GlobalEnv)
-      if (dev.cur() > 1 && length(recordPlot()) > 0) {
+      rec_plot <- recordPlot()
+      if (dev.cur() > 1 && inherits(rec_plot, "recordedplot")) {
         plot_file <- file.path(img_dir, paste0("plot_", format(Sys.time(), "%Y%m%d_%H%M%S_"), plot_index, ".png"))
         png(file = plot_file, width = 800, height = 600)
-        replayPlot(recordPlot())
+        replayPlot(rec_plot)
         dev.off()
         plot_files <- c(plot_files, plot_file)
         plot_index <- plot_index + 1


### PR DESCRIPTION
## Summary
- ensure recordPlot() check uses `inherits(..., 'recordedplot')`
- store recorded plot before using it for replay

## Testing
- `Rscript -e 'devtools::test()'`


------
https://chatgpt.com/codex/tasks/task_e_6853321a11108326a468551e5381320b