### PR TITLE
Add CLI auto-start feature

### DIFF
--- a/tests/testthat/test-cli-autostart.R
+++ b/tests/testthat/test-cli-autostart.R
@@ -1,0 +1,9 @@
+test_that("CLI auto-starts server", {
+  skip_on_cran()
+  script <- file.path("..", "..", "tools", "clir.sh")
+  out <- processx::run("bash", c(script, "exec", "autotest", "-e", "1+1"), error_on_status = FALSE)
+  expect_equal(out$status, 0)
+  result <- jsonlite::fromJSON(out$stdout)
+  expect_equal(result$result_summary$type, "double")
+  processx::run("bash", c(script, "stop", "autotest"))
+})


### PR DESCRIPTION
## Summary
- add auto-start logic to Python and Bash CLI tools
- redirect startup messages to stderr
- default to port 8080 when label unknown
- test CLI auto-start behavior

## Testing
- `micromamba run -n myr R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_685333e5cc288326bd7d04b4cefe080e