### PR TITLE
Fix warning capture initialization

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -17,7 +17,9 @@ exec_code <- function(code, port = 8080, plain = FALSE, summary = TRUE,
   if (plain) {
     httr::content(res, as = "text", encoding = "UTF-8")
   } else {
-    jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8"), simplifyVector = FALSE)
+    out <- jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8"), simplifyVector = FALSE)
+    if (!warnings) out$warning <- NULL
+    out
   }
 }
 

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -88,7 +88,7 @@ capture_output <- function(expr) {
   temp_output <- NULL
   temp_error <- NULL
   temp_plot <- NULL
-  temp_warning <- NULL
+  temp_warning <- character()
   temp_result <- NULL
 
   output_conn <- textConnection("temp_output", "w", local = TRUE)


### PR DESCRIPTION
## Summary
- initialize `temp_warning` as an empty character vector
- remove warnings field in the client when warnings=FALSE

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6853320d33b48326a9546d58e021f24c