### PR TITLE
Fix JSON output in CLI autostart

### DIFF
--- a/tools/clir.sh
+++ b/tools/clir.sh
@@ -34,7 +34,7 @@ start_instance() {
   Rscript "$script" --background --port "$port" >/dev/null 2>&1 &
   local pid=$!
   echo "${label}:${port}:${pid}" >> "${INST_FILE}"
-  echo "Started '${label}' on port ${port} (PID ${pid})"
+  echo "Started '${label}' on port ${port} (PID ${pid})" >&2
 }
 
 case "$1" in


### PR DESCRIPTION
## Summary
- ensure CLI startup messages don't pollute JSON output

## Testing
- `Rscript -e "devtools::test('.')"`

------
https://chatgpt.com/codex/tasks/task_e_6853a86518d08326827e51202be6525b