### PR TITLE
Allow multi-word --command expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ micromamba activate myr
 R -q -e "devtools::test()"
 ```
 
+## Command line usage
+
+Evaluate a single expression directly from the shell using the `--command`
+option. Quote the expression so it is passed as one argument:
+
+```bash
+replr --command "1 + 1"
+```
+

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -18,12 +18,13 @@ if (length(args) > 0) {
       i <- i + 1
     } else if (args[i] == "--command" || args[i] == "-c") {
       if (i + 1 <= length(args)) {
-        command_to_run <- args[i + 1]
+        command_to_run <- paste(args[(i + 1):length(args)], collapse = " ")
         run_mode <- "command"
-        i <- i + 2
+        break
       } else {
         stop("Missing command after --command|-c")
       }
+      i <- length(args) + 1
     } else if (args[i] == "--port" || args[i] == "-p") {
       if (i + 1 <= length(args)) {
         port <- as.integer(args[i + 1])
@@ -349,7 +350,6 @@ if (run_mode == "interactive" || run_mode == "background") {
       write(format(Sys.time(), "%Y-%m-%d %H:%M:%S"), heartbeat_file)
       last_call_time <- Sys.time()
     }
-  }
   }
 } else if (run_mode == "command") {
   cat("Executing command:", command_to_run, "\n")

--- a/tests/testthat/test-command-option.R
+++ b/tests/testthat/test-command-option.R
@@ -1,0 +1,11 @@
+test_that("--command works with quoted expressions", {
+  skip_on_cran()
+  out <- processx::run(
+    "Rscript",
+    c(system.file("scripts", "replr_server.R", package = "replr"),
+      "--command", "sum(1:5)"),
+    echo = FALSE,
+    error_on_status = FALSE
+  )
+  expect_equal(out$status, 0)
+})


### PR DESCRIPTION
## Summary
- handle all arguments after `--command` when starting replr
- document quoting with `--command`
- test `--command "sum(1:5)"`

## Testing
- `R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_6853b9b7d4b88326a9972d2a30093da7