### PR TITLE
Add full_results option

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -1,11 +1,29 @@
+#' Execute code on the replr server
+#'
+#' Sends R expressions to a running `replr` server and returns the parsed JSON
+#' response. Use `full_results = TRUE` to include the complete result object in
+#' the response.
+#'
+#' @param code Character string of R code to evaluate.
+#' @param port Server port number.
+#' @param plain Return plain text instead of JSON.
+#' @param summary Include a summary of the result object.
+#' @param output,warnings,error Include captured output, warnings and errors.
+#' @param full_results Logical; if `TRUE`, bypass summarization and include the
+#'   full result object. This may produce large responses and expose sensitive
+#'   data.
+#' @return A list representing the JSON response from the server.
+#' @export
 exec_code <- function(code, port = 8080, plain = FALSE, summary = TRUE,
-                      output = TRUE, warnings = TRUE, error = TRUE) {
+                      output = TRUE, warnings = TRUE, error = TRUE,
+                      full_results = FALSE) {
   query <- list()
   if (plain) query$format <- "text"
-  if (!summary) query$summary <- "false"
+  if (!summary || full_results) query$summary <- "false"
   if (!output) query$output <- "false"
   if (!warnings) query$warnings <- "false"
   if (!error) query$error <- "false"
+  if (full_results) query$full_results <- "true"
   qs <- if (length(query) > 0)
     paste0("?", paste(names(query), query, sep = "=", collapse = "&")) else ""
   url <- sprintf("http://127.0.0.1:%d/execute%s", as.integer(port), qs)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ exec_code("1 + 1", port = 8080)
 
 Use `server_status()` to confirm the server is running, and `stop_server()` to shut it down.
 
+### Returning full results
+
+`exec_code()` normally returns a summary of the evaluated object. Set
+`full_results = TRUE` to include the entire object in the JSON response.
+Be mindful that this may expose sensitive data or generate very large
+responses.
+
 ## Running tests
 
 After activating the `myr` environment, run the unit tests with:

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -158,7 +158,14 @@ process_request <- function(req) {
 
   qs <- parse_query_string(req$QUERY_STRING)
   plain_text <- isTRUE(as.logical(qs$plain)) || identical(qs$format, "text")
-  summary_enabled <- if (!is.null(qs$summary)) as.logical(qs$summary) else TRUE
+  full_results <- if (!is.null(qs$full_results)) as.logical(qs$full_results) else FALSE
+  summary_enabled <- if (!is.null(qs$summary)) {
+    as.logical(qs$summary)
+  } else if (full_results) {
+    FALSE
+  } else {
+    TRUE
+  }
   include_output <- if (!is.null(qs$output)) as.logical(qs$output) else getOption("rjson.output", TRUE)
   include_warnings <- if (!is.null(qs$warnings)) as.logical(qs$warnings) else getOption("rjson.warnings", TRUE)
   include_error <- if (!is.null(qs$error)) as.logical(qs$error) else getOption("rjson.error", TRUE)
@@ -266,6 +273,7 @@ process_request <- function(req) {
         if (include_error) response$error <- result$error
         if (include_warnings) response$warning <- result$warning
         response$plots <- result$plots
+        if (full_results) response$result <- result$result
         if (summary_enabled) response$result_summary <- result$result_summary
         if (nchar(result$error) > 0) {
           server_state$last_error <- result$error

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -34,3 +34,13 @@ test_that("errors are captured correctly", {
   expect_equal(res$output, "")
   expect_match(res$error, "non-numeric")
 })
+
+test_that("full results are returned when requested", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8127, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE)
+  expect_equal(unlist(res$result$a), 1:3)
+  expect_false("result_summary" %in% names(res))
+})


### PR DESCRIPTION
## Summary
- support `full_results` in `exec_code()` to bypass summarization
- send new flag in server and return raw result
- document option in README and roxygen docs
- test retrieving full results

## Testing
- `micromamba run -n myr R -q -e "devtools::test()"`


------
https://chatgpt.com/codex/tasks/task_e_6853b71d662c8326af4d82ca30e03245