### PR TITLE
Default exec_code() to plain text

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -1,8 +1,8 @@
 #' Execute code on the replr server
 #'
-#' Sends R expressions to a running `replr` server and returns the parsed JSON
-#' response. Use `full_results = TRUE` to include the complete result object in
-#' the response.
+#' Sends R expressions to a running `replr` server. By default the result is
+#' returned as plain text. Set `plain = FALSE` to receive parsed JSON. Use
+#' `full_results = TRUE` to include the complete result object in the response.
 #'
 #' @param code Character string of R code to evaluate.
 #' @param port Server port number.
@@ -12,14 +12,15 @@
 #' @param full_results Logical; if `TRUE`, bypass summarization and include the
 #'   full result object. This may produce large responses and expose sensitive
 #'   data.
-#' @return A list representing the JSON response from the server.
+#' @return By default a character string of plain text. When `plain = FALSE` a
+#'   list representing the JSON response from the server is returned.
 #' @export
-exec_code <- function(code, port = 8080, plain = FALSE, summary = TRUE,
+exec_code <- function(code, port = 8080, plain = TRUE, summary = FALSE,
                       output = TRUE, warnings = TRUE, error = TRUE,
                       full_results = FALSE) {
   query <- list()
   if (plain) query$format <- "text"
-  if (!summary || full_results) query$summary <- "false"
+  if (!summary && !full_results) query$summary <- "false"
   if (!output) query$output <- "false"
   if (!warnings) query$warnings <- "false"
   if (!error) query$error <- "false"

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ library(replr)
 start_server(port = 8080, background = TRUE)
 
 exec_code("1 + 1", port = 8080)
+#> [1] 2
 ```
 
 Use `server_status()` to confirm the server is running, and `stop_server()` to shut it down.
 
 ### Returning full results
 
-`exec_code()` normally returns a summary of the evaluated object. Set
-`full_results = TRUE` to include the entire object in the JSON response.
-Be mindful that this may expose sensitive data or generate very large
-responses.
+`exec_code()` returns plain text by default. Set `plain = FALSE` to obtain a
+parsed JSON response. Use `summary = TRUE` or `full_results = TRUE` to request
+additional detail from the server.
 
 ## Running tests
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -10,11 +10,11 @@ The package exposes a few core functions:
 
 - `start_server(port = 8080, background = FALSE)` — launches the JSON server. If
   `background = TRUE` the call returns immediately with the server running in
-the background.
+  the background.
 - `stop_server(port = 8080)` — sends a shutdown request to the server.
-- `exec_code(code, port = 8080, plain = FALSE, summary = TRUE, output = TRUE,
+- `exec_code(code, port = 8080, plain = TRUE, summary = FALSE, output = TRUE,
   warnings = TRUE, error = TRUE)` — submit R code to the running server and
-  return the parsed JSON response. Setting `plain = TRUE` returns plain text.
+  return plain text. Set `plain = FALSE` for parsed JSON output.
 - `server_status(port = 8080)` — retrieve basic information such as uptime and
   process id.
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -3,7 +3,7 @@ test_that("round-trip code returns expected result", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8123, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("1+1", port=8123)
+  res <- replr::exec_code("1+1", port=8123, plain = FALSE, summary = TRUE)
   expect_equal(res$result_summary$type, "double")
 })
 
@@ -21,7 +21,8 @@ test_that("warnings can be suppressed", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8125, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE)
+  res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE,
+                           plain = FALSE, summary = TRUE)
   expect_false("warning" %in% names(res))
 })
 
@@ -30,7 +31,7 @@ test_that("errors are captured correctly", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8126, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("log('foo')", port=8126)
+  res <- replr::exec_code("log('foo')", port=8126, plain = FALSE, summary = TRUE)
   expect_equal(res$output, "")
   expect_match(res$error, "non-numeric")
 })
@@ -40,7 +41,8 @@ test_that("full results are returned when requested", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8127, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE)
+  res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE,
+                          plain = FALSE)
   expect_equal(unlist(res$result$a), 1:3)
   expect_false("result_summary" %in% names(res))
 })

--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -42,42 +42,27 @@ replr::stop_server(port = 8123)
 
 # Executing Code
 
-`exec_code()` sends R expressions to the server for evaluation. The response is
-a list that can include standard output, warnings, errors, plot paths and a
-summary of the result.
+`exec_code()` sends R expressions to the server for evaluation. By default the
+result is returned as plain text.
 
 ```{r exec-code, eval=FALSE}
 res <- replr::exec_code("1 + 1", port = 8123)
 res
-## $status
-## [1] "success"
-##
-## $output
-## [1] ""
-##
-## $error
-## [1] ""
-##
-## $plots
-## [1] "r_comm/images/plot_20250618_203333_1.png"
-##
-## $result_summary
-## $result_summary$type
-## [1] "double"
+## [1] 2
 ```
 
 ## Controlling the Output
 
-Several arguments let you tailor the response:
+- Several arguments let you tailor the response:
 
-- `plain`: return the result as plain text.
-- `summary`: include a summary of the returned value.
+- `plain`: set to `FALSE` to return parsed JSON.
+- `summary`: include a summary of the returned value when JSON is requested.
 - `output`, `warnings`, `error`: toggle these fields in the response.
 
 ```{r custom-call, eval=FALSE}
 # return only the calculated value as plain text
-replr::exec_code("sqrt(25)", port = 8123, plain = TRUE)
-## [1] "{\"status\":\"success\",\"output\":\"\",\"error\":\"\",\"plots\":\"r_comm/images/plot_20250618_203333_2.png\",\"result_summary\":{\"type\":\"double\"}}"
+replr::exec_code("sqrt(25)", port = 8123)
+## [1] 5
 ```
 
 # Converting to a Tibble
@@ -86,7 +71,8 @@ The response object has an S3 method `as_tibble()` which converts the result to
 an easy-to-work-with tibble.
 
 ```{r as-tibble, eval=FALSE}
-res <- replr::exec_code("summary(lm(mpg ~ cyl, data = mtcars))", port = 8123)
+res <- replr::exec_code("summary(lm(mpg ~ cyl, data = mtcars))", port = 8123,
+                         plain = FALSE)
 
 tibble <- as_tibble(res)
 tibble
@@ -106,30 +92,10 @@ library(replr)
 start_server(port = 8123, background = TRUE)
 
 exec_code("mean(1:5)", port = 8123)
-## $status
-## [1] "success"
-##
-## $output
-## [1] ""
-##
-## $error
-## [1] ""
-##
-## $plots
-## [1] "r_comm/images/plot_20250618_203333_3.png"
-##
-## $result_summary
-## $result_summary$type
-## [1] "double"
+## [1] 3
 exec_code("plot(1:10)", port = 8123)
-## $status
-## [1] "success"
-##
-## $plots
-## [1] "r_comm/images/plot_20250618_203333_4.png"
 exec_code("warning('demo')", port = 8123)
-## $warning
-## [1] "demo"
+## Warning: demo
 
 stop_server(port = 8123)
 ```


### PR DESCRIPTION
## Summary
- exec_code() now defaults to `plain = TRUE` and `summary = FALSE`
- update README and docs for new defaults
- adjust tests for plain text default

## Testing
- `micromamba activate myr`
- `R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_6853d851afd88326a1b6c11d44c951b5