### PR TITLE
Add preview_rows option

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,9 @@
+.onLoad <- function(libname, pkgname) {
+  op <- options()
+  op.replr <- list(
+    replr.preview_rows = 5
+  )
+  toset <- !(names(op.replr) %in% names(op))
+  if (any(toset)) options(op.replr[toset])
+  invisible()
+}

--- a/README.md
+++ b/README.md
@@ -57,3 +57,10 @@ option. Quote the expression so it is passed as one argument:
 replr --command "1 + 1"
 ```
 
+### Global options
+
+`replr` uses a few R options for customization. The number of rows shown in
+data frame summaries is controlled by `replr.preview_rows` which defaults to `5`.
+Set this option before starting the server (or via `exec_code()` once running)
+to change how many rows are returned in previews.
+

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -18,6 +18,12 @@ the background.
 - `server_status(port = 8080)` — retrieve basic information such as uptime and
   process id.
 
+### Global options
+
+The preview length for summaries is controlled by `replr.preview_rows`.
+It defaults to `5`. Set `options(replr.preview_rows = n)` before sending
+commands to adjust how many rows are shown in previews.
+
 ## Bash command line (tools/clir.sh)
 
 The `tools` directory contains small clients for shells. The Bash script

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -8,6 +8,9 @@ args <- commandArgs(trailingOnly = TRUE)
 run_mode <- "interactive"  # Default mode
 command_to_run <- NULL
 port <- 8080  # Default port
+if (is.null(getOption("replr.preview_rows"))) {
+  options(replr.preview_rows = 5)
+}
 
 # Process command line arguments
 if (length(args) > 0) {
@@ -228,7 +231,7 @@ process_request <- function(req) {
               type = "data.frame",
               dim = dim(result$result),
               columns = names(result$result),
-              preview = head(result$result, 10)
+              preview = head(result$result, getOption("replr.preview_rows", 5))
             )
           }
           else if (inherits(result$result, "lm") || inherits(result$result, "glm")) {
@@ -259,7 +262,7 @@ process_request <- function(req) {
             result$result_summary <- list(
               type = typeof(result$result),
               length = length(result$result),
-              preview = head(result$result, 10)
+              preview = head(result$result, getOption("replr.preview_rows", 5))
             )
           }
           else {

--- a/tests/testthat/test-preview-option.R
+++ b/tests/testthat/test-preview-option.R
@@ -1,0 +1,18 @@
+test_that("default preview_rows is 5", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8130, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8130)
+  expect_equal(length(res$result_summary$preview), 5)
+})
+
+test_that("preview_rows option can be changed", {
+  skip_on_cran()
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8131, "--background"))
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  replr::exec_code("options(replr.preview_rows=3)", port=8131)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8131)
+  expect_equal(length(res$result_summary$preview), 3)
+})


### PR DESCRIPTION
## Summary
- add `replr.preview_rows` option with default 5
- respect this option in `replr_server.R`
- document the option in README and TOOL_GUIDE
- add tests for preview row behaviour

## Testing
- `R -q -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_6853d872555c8326aa9962a6ac3c66f8