### PR TITLE
Update docs for suppressing warnings/errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Use `server_status()` to confirm the server is running, and `stop_server()` to s
 Be mindful that this may expose sensitive data or generate very large
 responses.
 
+### Controlling warnings and errors
+
+By default the server captures any warnings and errors just as they would
+appear in an interactive R session. These messages are returned in the JSON
+response under the `warning` and `error` fields. To silence them you can set
+`warnings = FALSE` or `error = FALSE`:
+
+```R
+exec_code("warning('oops'); 1", port = 8080, warnings = FALSE)
+exec_code("log('foo')", port = 8080, error = FALSE)
+```
+
+When using `curl` directly you can pass query parameters:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"command":"warning(\"hi\");1"}' \
+  "http://127.0.0.1:8080/execute?warnings=false"
+```
+
 ## Running tests
 
 After activating the `myr` environment, run the unit tests with:

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -14,7 +14,9 @@ the background.
 - `stop_server(port = 8080)` — sends a shutdown request to the server.
 - `exec_code(code, port = 8080, plain = FALSE, summary = TRUE, output = TRUE,
   warnings = TRUE, error = TRUE)` — submit R code to the running server and
-  return the parsed JSON response. Setting `plain = TRUE` returns plain text.
+  return the parsed JSON response. By default warnings and errors are captured
+  so the JSON mimics interactive R evaluation. Set `warnings = FALSE` or
+  `error = FALSE` to suppress them. Setting `plain = TRUE` returns plain text.
 - `server_status(port = 8080)` — retrieve basic information such as uptime and
   process id.
 
@@ -29,6 +31,15 @@ clir.sh stop [label]             # stop the labelled instance
 clir.sh status [label]           # query status of instance
 clir.sh exec [label] -e CODE     # execute code (or pipe via stdin)
 clir.sh list                     # list known instances
+```
+
+To omit warnings or errors from the JSON output, include query parameters when
+calling the endpoint directly:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"command":"warning(\"a\")"}' \
+  "http://127.0.0.1:8080/execute?warnings=false"
 ```
 
 Instances are tracked under `~/.replr/instances`. Labels default to


### PR DESCRIPTION
## Summary
- document how to disable warnings and errors in README
- describe default behaviour and suppression options in TOOL_GUIDE
- show curl example for passing warnings=false

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6853d88ed3c883269db239af7290276d