### PR TITLE
Add preview rows option docs

### DIFF
--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -74,6 +74,19 @@ Several arguments let you tailor the response:
 - `summary`: include a summary of the returned value.
 - `output`, `warnings`, `error`: toggle these fields in the response.
 
+To change how many rows of a data frame are shown in the summary preview, set
+the global option `replr.preview_rows`:
+
+```{r preview-option, eval=FALSE}
+options(replr.preview_rows = 10)
+```
+
+Summaries can be disabled entirely:
+
+```{r disable-summary, eval=FALSE}
+replr::exec_code("mean(1:5)", port = 8123, summary = FALSE)
+```
+
 ```{r custom-call, eval=FALSE}
 # return only the calculated value as plain text
 replr::exec_code("sqrt(25)", port = 8123, plain = TRUE)


### PR DESCRIPTION
## Summary
- document how to change preview rows with `options(replr.preview_rows = 10)`
- explain disabling summaries with `summary = FALSE`

## Testing
- `R -q -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_6853d89711408326b4a5d1f07c2176e1