### PR TITLE
Add tests for plain text results

### DIFF
--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -9,11 +9,29 @@ test_that("round-trip code returns expected result", {
 
 test_that("plain text mode works", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8124, "--background"))
+  ps <- processx::process$new(
+    "Rscript",
+    c(system.file("scripts", "replr_server.R", package = "replr"),
+      "--port", 8124, "--background")
+  )
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("1+1", port=8124, plain = TRUE)
-  expect_match(res, "2")
+  res <- replr::exec_code("1+1", port = 8124, plain = TRUE)
+  expect_type(res, "character")
+  expect_match(res, "\\[1\\] 2")
+})
+
+test_that("explicit plain = FALSE returns JSON", {
+  skip_on_cran()
+  ps <- processx::process$new(
+    "Rscript",
+    c(system.file("scripts", "replr_server.R", package = "replr"),
+      "--port", 8128, "--background")
+  )
+  on.exit(ps$kill())
+  Sys.sleep(1)
+  res <- replr::exec_code("1+1", port = 8128, plain = FALSE)
+  expect_equal(res$result_summary$type, "double")
 })
 
 test_that("warnings can be suppressed", {

--- a/tests/testthat/test-cli-autostart.R
+++ b/tests/testthat/test-cli-autostart.R
@@ -1,9 +1,28 @@
 test_that("CLI auto-starts server", {
   skip_on_cran()
   script <- file.path("..", "..", "tools", "clir.sh")
-  out <- processx::run("bash", c(script, "exec", "autotest", "-e", "1+1"), error_on_status = FALSE)
+  out <- processx::run(
+    "bash",
+    c(script, "exec", "autotest", "-e", "1+1"),
+    error_on_status = FALSE
+  )
   expect_equal(out$status, 0)
+  expect_type(out$stdout, "character")
   result <- jsonlite::fromJSON(out$stdout)
   expect_equal(result$result_summary$type, "double")
   processx::run("bash", c(script, "stop", "autotest"))
+})
+
+test_that("CLI returns JSON when --json supplied", {
+  skip_on_cran()
+  script <- file.path("..", "..", "tools", "clir.sh")
+  out <- processx::run(
+    "bash",
+    c(script, "exec", "autotest2", "--json", "-e", "1+1"),
+    error_on_status = FALSE
+  )
+  expect_equal(out$status, 0)
+  result <- jsonlite::fromJSON(out$stdout)
+  expect_equal(result$result_summary$type, "double")
+  processx::run("bash", c(script, "stop", "autotest2"))
 })


### PR DESCRIPTION
## Summary
- enhance plain text verification in `test-basic.R`
- add explicit JSON case for `exec_code`
- adjust CLI tests to parse text before verifying JSON

## Testing
- `NOT_CRAN=true R -q -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_6853d87989e08326a89b809a6f34d51c