### PR TITLE
Switch API defaults to text output

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -1,7 +1,7 @@
 #' Execute code on the replr server
 #'
-#' Sends R expressions to a running `replr` server and returns console text by
-#' default. Set `plain = FALSE` to request a JSON response. Use
+#' Sends R expressions to a running `replr` server. By default the result is
+#' returned as plain text. Set `plain = FALSE` to receive parsed JSON. Use
 #' `full_results = TRUE` to include the complete result object in the response.
 #'
 #' @param code Character string of R code to evaluate.
@@ -12,9 +12,10 @@
 #' @param full_results Logical; if `TRUE`, bypass summarization and include the
 #'   full result object. This may produce large responses and expose sensitive
 #'   data.
-#' @return A list representing the JSON response from the server.
+#' @return By default a character string of plain text. When `plain = FALSE` a
+#'   list representing the JSON response from the server is returned.
 #' @export
-exec_code <- function(code, port = 8080, plain = TRUE, summary = TRUE,
+exec_code <- function(code, port = 8080, plain = TRUE, summary = FALSE,
                       output = TRUE, warnings = TRUE, error = TRUE,
                       full_results = FALSE) {
   query <- list()
@@ -23,7 +24,7 @@ exec_code <- function(code, port = 8080, plain = TRUE, summary = TRUE,
   } else {
     query$plain <- "false"
   }
-  if (!summary || full_results) query$summary <- "false"
+  if (!summary && !full_results) query$summary <- "false"
   if (!output) query$output <- "false"
   if (!warnings) query$warnings <- "false"
   if (!error) query$error <- "false"

--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ Use `server_status()` to confirm the server is running, and `stop_server()` to s
 
 ### Returning full results
 
-`exec_code()` normally returns a summary of the evaluated object. Set
-`full_results = TRUE` to include the entire object in the JSON response.
-Be mindful that this may expose sensitive data or generate very large
-responses.
+`exec_code()` returns plain text by default. Set `plain = FALSE` to obtain a
+parsed JSON response. Use `summary = TRUE` or `full_results = TRUE` to request
+additional detail from the server.
 
 ### Controlling warnings and errors
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -12,9 +12,9 @@ The package exposes a few core functions:
   `background = TRUE` the call returns immediately with the server running in
 the background.
 - `stop_server(port = 8080)` — sends a shutdown request to the server.
-- `exec_code(code, port = 8080, plain = TRUE, summary = TRUE, output = TRUE,
-  warnings = TRUE, error = TRUE)` — submit R code to the running server. It
-  prints console text by default; set `plain = FALSE` to receive JSON.
+- `exec_code(code, port = 8080, plain = TRUE, summary = FALSE, output = TRUE,
+  warnings = TRUE, error = TRUE)` — submit R code to the running server and
+  return plain text. Set `plain = FALSE` for parsed JSON output.
 - `server_status(port = 8080)` — retrieve basic information such as uptime and
   process id.
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -3,7 +3,7 @@ test_that("round-trip code returns expected result", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8123, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("1+1", port=8123, plain = FALSE)
+  res <- replr::exec_code("1+1", port=8123, plain = FALSE, summary = TRUE)
   expect_equal(res$result_summary$type, "double")
 })
 
@@ -30,7 +30,7 @@ test_that("explicit plain = FALSE returns JSON", {
   )
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("1+1", port = 8128, plain = FALSE)
+  res <- replr::exec_code("1+1", port = 8128, plain = FALSE, summary = TRUE)
   expect_equal(res$result_summary$type, "double")
 })
 
@@ -39,7 +39,8 @@ test_that("warnings can be suppressed", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8125, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE, plain = FALSE)
+  res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE,
+                           plain = FALSE, summary = TRUE)
   expect_false("warning" %in% names(res))
 })
 
@@ -48,7 +49,7 @@ test_that("errors are captured correctly", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8126, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("log('foo')", port=8126, plain = FALSE)
+  res <- replr::exec_code("log('foo')", port=8126, plain = FALSE, summary = TRUE)
   expect_equal(res$output, "")
   expect_match(res$error, "non-numeric")
 })
@@ -58,7 +59,8 @@ test_that("full results are returned when requested", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8127, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE, plain = FALSE)
+  res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE,
+                          plain = FALSE)
   expect_equal(unlist(res$result$a), 1:3)
   expect_false("result_summary" %in% names(res))
 })

--- a/tests/testthat/test-preview-option.R
+++ b/tests/testthat/test-preview-option.R
@@ -3,7 +3,8 @@ test_that("default preview_rows is 5", {
   ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8130, "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
-  res <- replr::exec_code("data.frame(a=1:10)", port=8130)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8130,
+                          plain = FALSE, summary = TRUE)
   expect_equal(length(res$result_summary$preview), 5)
 })
 
@@ -13,6 +14,7 @@ test_that("preview_rows option can be changed", {
   on.exit(ps$kill())
   Sys.sleep(1)
   replr::exec_code("options(replr.preview_rows=3)", port=8131)
-  res <- replr::exec_code("data.frame(a=1:10)", port=8131)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8131,
+                          plain = FALSE, summary = TRUE)
   expect_equal(length(res$result_summary$preview), 3)
 })

--- a/tools/clir.ps1
+++ b/tools/clir.ps1
@@ -70,7 +70,7 @@ switch ($cmd) {
         $port = Port-Of $label $inst
         $body = @{ command = $code } | ConvertTo-Json
         $url = "http://127.0.0.1:$port/execute"
-        if (-not $json) { $url = "$url?format=text" }
+        if (-not $json) { $url = "$url?format=text" } else { $url = "$url?plain=false" }
         $resp = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType 'application/json'
         if ($json) { $resp | ConvertTo-Json -Depth 10 } else { $resp }
     }

--- a/tools/clir.py
+++ b/tools/clir.py
@@ -91,6 +91,8 @@ def exec_code(label: str, code: str | None, json_out: bool = False) -> None:
         url = f"http://127.0.0.1:{port}/execute"
         if not json_out:
             url += "?format=text"
+        else:
+            url += "?plain=false"
         return requests.post(url, json={"command": code})
 
     try:

--- a/tools/clir.sh
+++ b/tools/clir.sh
@@ -87,6 +87,8 @@ case "$1" in
     url="http://127.0.0.1:${port}/execute"
     if [[ $json -eq 0 ]]; then
       url="${url}?format=text"
+    else
+      url="${url}?plain=false"
     fi
     curl -s -X POST -H "Content-Type: application/json" \
          -d "{\"command\":$(jq -Rs . <<<"$code")}" \

--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -43,9 +43,8 @@ replr::stop_server(port = 8123)
 
 # Executing Code
 
-`exec_code()` sends R expressions to the server for evaluation. The response is
-a list that can include standard output, warnings, errors, plot paths and a
-summary of the result.
+`exec_code()` sends R expressions to the server for evaluation. By default the
+result is returned as plain text.
 
 ```{r exec-code, eval=FALSE}
 # returns console text
@@ -61,8 +60,8 @@ res$result_summary$type
 
 Several arguments let you tailor the response:
 
-- `plain`: return console text (`TRUE`) or JSON (`FALSE`).
-- `summary`: include a summary of the returned value.
+- `plain`: set to `FALSE` to return parsed JSON.
+- `summary`: include a summary of the returned value when JSON is requested.
 - `output`, `warnings`, `error`: toggle these fields in the response.
 
 To change how many rows of a data frame are shown in the summary preview, set


### PR DESCRIPTION
## Summary
- default client summary off and document that text is returned
- adjust guides and vignette for new defaults
- add `plain=false` handling in CLI helpers
- update tests for explicit summary requests

## Testing
- `micromamba run -n myr R -q -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_68540e9ba5108326b796293a9e0b2acf