### PR TITLE
Update CLI help for JSON output fields

### DIFF
--- a/tools/clir.py
+++ b/tools/clir.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Simple cross-platform CLI for replr_server."""
+"""Simple cross-platform CLI for ``replr_server``.
+
+When ``exec`` is invoked with ``--json`` the server returns
+a JSON object containing the fields ``output``, ``warning``,
+``error``, ``plots``, ``result_summary`` and ``result``.
+"""
 
 import argparse
 import json

--- a/tools/clir.sh
+++ b/tools/clir.sh
@@ -103,6 +103,10 @@ case "$1" in
   *)
     cat <<EOF
 Usage: clir.sh {start [label] [port]|stop [label]|status [label]|exec [label] [-e CODE] [--json]|exec [label] < script.R|list}
+
+When '--json' is supplied to 'exec', the server responds with
+a JSON object containing: output, warning, error, plots,
+result_summary and result.
 EOF
     ;;
 esac


### PR DESCRIPTION
## Summary
- refresh clir.py docstring to describe JSON output fields
- expand clir.sh usage message with JSON field info

## Testing
- `R -q -e "devtools::test()"`
- `./tools/clir.sh exec test -e '1+1' --json`
- `python3 tools/clir.py exec test -e '1+1' --json`


------
https://chatgpt.com/codex/tasks/task_e_685411dc5488832681c689e05222dc8c