### PR TITLE
Add console output expectation

### DIFF
--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -5,6 +5,7 @@ test_that("round-trip code returns expected result", {
   Sys.sleep(1)
   res <- replr::exec_code("1+1", port=8123, plain = FALSE, summary = TRUE)
   expect_equal(res$result_summary$type, "double")
+  expect_match(res$output, "\\[1\\] 2")
 })
 
 test_that("plain text mode works", {


### PR DESCRIPTION
## Summary
- verify console output is present for JSON response when executing basic code

## Testing
- `NOT_CRAN=true Rscript -e 'devtools::test()'` *(fails: res$output does not match "[1] 2")*

------
https://chatgpt.com/codex/tasks/task_e_685411dab2c08326b3fe4b9fe4bffba3