### PR TITLE
Update docs for JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ start_server(port = 8080, background = TRUE)
 
 # returns console text
 exec_code("1 + 1", port = 8080)
+## [1] 2
 
 # request JSON instead
 exec_code("1 + 1", port = 8080, plain = FALSE)
+## {
+##   "output": "[1] 2",
+##   "error": "",
+##   "plots": "",
+##   "result_summary": {"type": "double"}
+## }
 ```
 
 Use `server_status()` to confirm the server is running, and `stop_server()` to shut it down.
@@ -103,9 +110,11 @@ option. Quote the expression so it is passed as one argument:
 
 ```bash
 replr --command "1 + 1"           # plain text output
+#> [1] 2
 
 # request JSON
 replr --command "1 + 1" --json
+#> {"output":"[1] 2","error":"","plots":"","result_summary":{"type":"double"}}
 ```
 
 ### Global options

--- a/vignettes/bash-cli.Rmd
+++ b/vignettes/bash-cli.Rmd
@@ -40,8 +40,7 @@ $ echo 'sqrt(144)' | tools/clir.sh exec demo
 
 $ echo 'sqrt(144)' | tools/clir.sh exec demo --json
 {
-  "status": "success",
-  "output": "",
+  "output": "12",
   "error": "",
   "plots": "",
   "result_summary": {"type": "double"}

--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -52,6 +52,8 @@ replr::exec_code("1 + 1", port = 8123)
 
 # request JSON output
 res <- replr::exec_code("1 + 1", port = 8123, plain = FALSE)
+res$output
+## [1] "[1] 2"
 res$result_summary$type
 ## [1] "double"
 ```
@@ -112,14 +114,12 @@ start_server(port = 8123, background = TRUE)
 
 # console text
 exec_code("mean(1:5)", port = 8123)
+## [1] 3
 
 # JSON result
 exec_code("mean(1:5)", port = 8123, plain = FALSE)$result_summary$type
 ## [1] "double"
 exec_code("plot(1:10)", port = 8123)
-## $status
-## [1] "success"
-##
 ## $plots
 ## [1] "r_comm/images/plot_20250618_203333_4.png"
 exec_code("warning('demo')", port = 8123)


### PR DESCRIPTION
## Summary
- show new JSON result in README examples
- update vignettes to match revised output

## Testing
- `rmarkdown::render('vignettes/bash-cli.Rmd'); rmarkdown::render('vignettes/replr-usage.Rmd')`
- `devtools::test()`


------
https://chatgpt.com/codex/tasks/task_e_685411de42c48326868879c904cfb4e6