### PR TITLE
Fix tibble import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,5 +6,5 @@ Description: Launches a local httpuv-based REPL server for evaluating R code and
 License: MIT
 Encoding: UTF-8
 Depends: R (>= 3.5.0)
-Imports: httpuv, jsonlite, utils, httr
+Imports: httpuv, jsonlite, utils, httr, tibble
 Suggests: testthat, processx

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - r-httpuv
   - r-jsonlite
   - r-httr
+  - r-tibble


### PR DESCRIPTION
## Summary
- import tibble for rjson methods
- install r-tibble in the environment

## Testing
- `micromamba env update -n myr -f environment.yml`
- `micromamba run -n myr R CMD check --no-manual --as-cran replr_0.0.1.tar.gz`

------
https://chatgpt.com/codex/tasks/task_e_68541f90221c8326abf051e3eb4cca03