### PR TITLE
Modify exec_code calls for summary

### DIFF
--- a/tests/testthat/test-preview-option.R
+++ b/tests/testthat/test-preview-option.R
@@ -4,7 +4,7 @@ test_that("default preview_rows is 5", {
   on.exit(ps$kill())
   Sys.sleep(1)
 
-  res <- replr::exec_code("data.frame(a=1:10)", port=8130, plain = FALSE)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8130, plain = FALSE, summary = TRUE)
   expect_equal(length(res$result_summary$preview), 5)
 })
 
@@ -14,7 +14,7 @@ test_that("preview_rows option can be changed", {
   on.exit(ps$kill())
   Sys.sleep(1)
   replr::exec_code("options(replr.preview_rows=3)", port=8131, plain = FALSE)
-  res <- replr::exec_code("data.frame(a=1:10)", port=8131, plain = FALSE)
+  res <- replr::exec_code("data.frame(a=1:10)", port=8131, plain = FALSE, summary = TRUE)
 
   expect_equal(length(res$result_summary$preview), 3)
 })


### PR DESCRIPTION
## Summary
- test: use `summary=TRUE` when calling `exec_code()`

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_68541f8d35f88326814a5f872a834752