### PR TITLE
cleanup deps and doc python

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,5 +6,5 @@ Description: Launches a local httpuv-based REPL server for evaluating R code and
 License: MIT
 Encoding: UTF-8
 Depends: R (>= 3.5.0)
-Imports: httpuv, jsonlite, utils, httr
+Imports: httpuv, jsonlite, utils, httr, later, tibble
 Suggests: testthat, processx

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ small automation tasks or remote evaluation from other languages.
    micromamba activate myr
    ```
 3. Install the package from GitHub:
-   ```R
+  ```R
 
-   devtools::install_github("shanelindsay/replr")
+  devtools::install_github("shanelindsay/replr")
+  ```
+4. Install Python requirements for the optional CLI tool:
+   ```bash
+   pip install -r requirements.txt
    ```
 
 ## Basic usage

--- a/environment.yml
+++ b/environment.yml
@@ -4,16 +4,15 @@ channels:
 dependencies:
   - r-base
   # - r-tidyverse       # ggplot2, dplyr, tidyr, readr, etc.
-  - r-pak
-  - r-devtools        # Package development (e.g. install_github)
   #- r-rmarkdown       # Reproducible reports
   # - r-knitr           # R Markdown rendering
   - r-testthat        # Unit testing
   - r-processx
-  - r-renv            # Local dependency management
   #  - r-essentials     # Includes tidyverse, RStudio, etc.
   # - compilers       # Optional: Needed for building packages from source
   ## repl specific 
   - r-httpuv
   - r-jsonlite
   - r-httr
+  - r-later
+  - r-tibble

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- drop unused dev packages from environment.yml
- add later and tibble runtime deps
- list Python requests library in requirements.txt and README

## Testing
- `Rscript -e 'devtools::test()'` *(fails: preview option tests)*

------
https://chatgpt.com/codex/tasks/task_e_68541fab904c83269a50dcb9d10497d3