### PR TITLE
Add per-instance image directories

### DIFF
--- a/docs/cli_mtcars_demo.md
+++ b/docs/cli_mtcars_demo.md
@@ -116,7 +116,7 @@ If a command produces a plot, the path is printed even in plain text mode.
 
 ```bash
 $ tools/clir.sh exec demo -e 'plot(mtcars$wt, mtcars$mpg)'
-r_comm/images/plot_20250619_120000_1.png
+demo/images/plot_20250619_120000_1.png
 List of 1
  $ type: chr "NULL"
 ```
@@ -127,7 +127,7 @@ $ tools/clir.sh exec demo -e 'plot(mtcars$wt, mtcars$mpg)' --json
     "status": "success",
     "output": "",
     "error": "",
-  "plots": ["r_comm/images/plot_20250619_120000_1.png"],
+  "plots": ["demo/images/plot_20250619_120000_1.png"],
   "result_summary": {"type": "NULL"}
 }
 ```

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -62,16 +62,17 @@ if (length(missing_packages) > 0) {
 library(httpuv)
 library(jsonlite)
 
-img_dir <- "r_comm/images"
+base_dir <- Sys.getenv("REPLR_BASE_DIR", "r_comm")
+img_dir <- file.path(base_dir, "images")
 if (!dir.exists(img_dir)) {
   dir.create(img_dir, recursive = TRUE)
 }
 
 server <- NULL
 last_call_time <- Sys.time()
-heartbeat_file <- "r_comm/heartbeat.txt"
-process_state_file <- "r_comm/r_process_state.txt"
-process_pid_file <- "r_comm/r_process_pid.txt"
+heartbeat_file <- file.path(base_dir, "heartbeat.txt")
+process_state_file <- file.path(base_dir, "r_process_state.txt")
+process_pid_file <- file.path(base_dir, "r_process_pid.txt")
 write(Sys.getpid(), process_pid_file)
 
 server_state <- list(

--- a/tools/clir.sh
+++ b/tools/clir.sh
@@ -31,7 +31,8 @@ start_instance() {
   local port=$2
   local script_dir="$(cd "$(dirname "$0")" && pwd)"
   local script="$script_dir/../inst/scripts/replr_server.R"
-  Rscript "$script" --background --port "$port" >/dev/null 2>&1 &
+  mkdir -p "$label"
+  REPLR_BASE_DIR="$label" Rscript "$script" --background --port "$port" >/dev/null 2>&1 &
   local pid=$!
   echo "${label}:${port}:${pid}" >> "${INST_FILE}"
   echo "Started '${label}' on port ${port} (PID ${pid})" >&2

--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -121,7 +121,7 @@ exec_code("mean(1:5)", port = 8123, plain = FALSE)$result_summary$type
 ## [1] "double"
 exec_code("plot(1:10)", port = 8123)
 ## $plots
-## [1] "r_comm/images/plot_20250618_203333_4.png"
+## [1] "demo/images/plot_20250618_203333_4.png"
 exec_code("warning('demo')", port = 8123)
 ## $warning
 ## [1] "demo"


### PR DESCRIPTION
## Summary
- save server files under `REPLR_BASE_DIR` env var
- ensure CLI creates a directory named after the server label and uses it
- update docs and vignettes for new plot paths

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_6854820822a083269da263fedd058f46