### PR TITLE
Add jq check for clir.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ small automation tasks or remote evaluation from other languages.
 3. Install the package from GitHub:
   ```R
 
-  devtools::install_github("shanelindsay/replr")
+ devtools::install_github("shanelindsay/replr")
   ```
 4. Install Python requirements for the optional CLI tool:
    ```bash
    pip install -r requirements.txt
+   ```
+5. Install `jq`, required by `clir.sh` for encoding JSON:
+   ```bash
+   sudo apt-get install jq  # or use your package manager
    ```
 
 ## Basic usage

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -27,7 +27,7 @@ commands to adjust how many rows are shown in previews.
 ## Bash command line (tools/clir.sh)
 
 The `tools` directory contains small clients for shells. The Bash script
-`clir.sh` provides several subcommands:
+`clir.sh` requires `jq` for encoding JSON and provides several subcommands:
 
 ```bash
 clir.sh start [label] [port]     # start server and record instance

--- a/tools/clir.sh
+++ b/tools/clir.sh
@@ -2,6 +2,12 @@
 #
 # Very small CLI for the R JSON server described earlier.
 
+# Ensure jq is available for JSON encoding
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but was not found in PATH." >&2
+  exit 1
+fi
+
 CONFIG_DIR="${HOME}/.replr"
 INST_FILE="${CONFIG_DIR}/instances"
 DEFAULT_PORT=8080


### PR DESCRIPTION
## Summary
- ensure `jq` is available when using `clir.sh`
- document the jq requirement in README and TOOL_GUIDE

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_685483ab8e6c83268250d4d99314ebfd