### PR TITLE
Remove runtime installs and document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ small automation tasks or remote evaluation from other languages.
 
 ## Installation with micromamba
 
-1. Create the `myr` environment using the provided `environment.yml`:
+1. Create the `myr` environment using the provided `environment.yml`.
+   This file lists required R packages such as `r-httpuv` and `r-jsonlite` used
+   by the server.
    ```bash
    micromamba env create -f environment.yml
    ```

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - r-base
   - r-processx
-  - r-httpuv
-  - r-jsonlite
+  - r-httpuv      # required by replr_server
+  - r-jsonlite    # required by replr_server
   - r-httr
   - r-later
   - r-tibble

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -50,15 +50,6 @@ if (length(args) > 0) {
   }
 }
 
-# Check for required packages
-required_packages <- c("httpuv", "jsonlite")
-missing_packages <- required_packages[!sapply(required_packages, function(p) requireNamespace(p, quietly = TRUE))]
-
-if (length(missing_packages) > 0) {
-  cat("Installing missing packages:", paste(missing_packages, collapse = ", "), "\n")
-  install.packages(missing_packages, repos = "https://cran.rstudio.com/")
-}
-
 library(httpuv)
 library(jsonlite)
 


### PR DESCRIPTION
## Summary
- remove `install.packages()` logic from `replr_server.R`
- note required R packages in `environment.yml`
- update installation instructions in README

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_685483d7364883268fc138cbc489967f