### PR TITLE
Add test for Python CLI

### DIFF
--- a/tests/testthat/test-clir-py.R
+++ b/tests/testthat/test-clir-py.R
@@ -1,0 +1,29 @@
+test_that("Python CLI can start, exec code, and stop", {
+  skip_on_cran()
+  script <- normalizePath(file.path("..", "..", "tools", "clir.py"))
+  label <- "pytest"
+  port <- 8150
+  # run from the scripts directory so clir.py finds replr_server.R
+  workdir <- normalizePath(file.path("..", "..", "inst", "scripts"))
+  # start the server
+  start_status <- withr::with_dir(
+    workdir,
+    system2("python3", c(script, "start", label, as.character(port)))
+  )
+  expect_equal(start_status, 0)
+  on.exit(withr::with_dir(workdir,
+                          system2("python3", c(script, "stop", label))),
+          add = TRUE)
+  Sys.sleep(1)
+  # execute code requesting JSON output
+  out_exec <- processx::run(
+    "python3",
+    c(script, "exec", label, "--json", "-e", "1+1"),
+    wd = workdir,
+    error_on_status = FALSE
+  )
+  expect_equal(out_exec$status, 0)
+  json_text <- sub("^[^{]*", "", out_exec$stdout)
+  result <- jsonlite::fromJSON(json_text)
+  expect_equal(result$result_summary$type, "double")
+})


### PR DESCRIPTION
## Summary
- add new test for clir.py start, exec, and stop

## Testing
- `NOT_CRAN=true R -q -e "testthat::test_local('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_685483f294108326ac2fa7afae46fe4e