### PR TITLE
Add host argument to server and CLI

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1,7 +1,7 @@
-start_server <- function(port = 8080, background = FALSE) {
+start_server <- function(port = 8080, host = "127.0.0.1", background = FALSE) {
   script <- system.file("scripts", "replr_server.R", package = "replr")
-  cmd <- sprintf('Rscript "%s" --port %d %s',
-                 script, as.integer(port),
+  cmd <- sprintf('Rscript "%s" --port %d --host %s %s',
+                 script, as.integer(port), shQuote(host),
                  if (background) "--background" else "")
   system(cmd, wait = !background, invisible = TRUE)
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Start the server and execute some code:
 ```R
 library(replr)
 
-start_server(port = 8080, background = TRUE)
+start_server(port = 8080, host = "127.0.0.1", background = TRUE)
 
 # returns console text
 exec_code("1 + 1", port = 8080)
@@ -82,7 +82,7 @@ curl -s -X POST -H "Content-Type: application/json" \
 Launch a background server on a custom port:
 
 ```R
-start_server(port = 8080, background = TRUE)
+start_server(port = 8080, host = "127.0.0.1", background = TRUE)
 ```
 
 Stop that server instance when finished:
@@ -94,8 +94,8 @@ stop_server(port = 8080)
 The same operations can be performed from the command line:
 
 ```bash
-tools/clir.sh start default 8080
-tools/clir.sh stop 8080
+tools/clir.sh start default 8080 127.0.0.1
+tools/clir.sh stop 8080 127.0.0.1
 ```
 
 ## Running tests

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -8,7 +8,7 @@ JSON.
 
 The package exposes a few core functions:
 
-- `start_server(port = 8080, background = FALSE)` — launches the JSON server. If
+- `start_server(port = 8080, host = "127.0.0.1", background = FALSE)` — launches the JSON server. If
   `background = TRUE` the call returns immediately with the server running in
 the background.
 - `stop_server(port = 8080)` — sends a shutdown request to the server.
@@ -30,10 +30,10 @@ The `tools` directory contains small clients for shells. The Bash script
 `clir.sh` provides several subcommands:
 
 ```bash
-clir.sh start [label] [port]     # start server and record instance
-clir.sh stop [label]             # stop the labelled instance
-clir.sh status [label]           # query status of instance
-clir.sh exec [label] [-e CODE] [--json]  # execute code (or pipe via stdin)
+clir.sh start [label] [port] [host]     # start server and record instance
+clir.sh stop [label] [host]             # stop the labelled instance
+clir.sh status [label] [host]           # query status of instance
+clir.sh exec [label] [-e CODE] [--json] [host]  # execute code (or pipe via stdin)
 
 clir.sh list                     # list known instances
 ```
@@ -52,7 +52,7 @@ Instances are tracked under `~/.replr/instances`. Labels default to
 
 ```bash
 # start a server on port 8123 and label it mysrv
-clir.sh start mysrv 8123
+clir.sh start mysrv 8123 127.0.0.1
 
 # run a single command
 clir.sh exec mysrv -e '1+1'
@@ -60,10 +60,10 @@ clir.sh exec mysrv -e '1+1'
 clir.sh exec mysrv -e '1+1' --json
 
 # check status
-clir.sh status mysrv
+clir.sh status mysrv 127.0.0.1
 
 # stop the server
-clir.sh stop mysrv
+clir.sh stop mysrv 127.0.0.1
 ```
 
 ## Python and PowerShell

--- a/inst/scripts/replr_server.R
+++ b/inst/scripts/replr_server.R
@@ -8,6 +8,7 @@ args <- commandArgs(trailingOnly = TRUE)
 run_mode <- "interactive"  # Default mode
 command_to_run <- NULL
 port <- 8080  # Default port
+host <- "127.0.0.1"  # Default host
 if (is.null(getOption("replr.preview_rows"))) {
   options(replr.preview_rows = 5)
 }
@@ -35,12 +36,20 @@ if (length(args) > 0) {
       } else {
         stop("Missing port number after --port|-p")
       }
+    } else if (args[i] == "--host" || args[i] == "-H") {
+      if (i + 1 <= length(args)) {
+        host <- args[i + 1]
+        i <- i + 2
+      } else {
+        stop("Missing host after --host|-H")
+      }
     } else if (args[i] == "--help" || args[i] == "-h") {
       cat("Usage: Rscript replr_server.R [options]\n")
       cat("Options:\n")
       cat("  --background, -b     Run in background mode\n")
       cat("  --command, -c CMD    Execute a single command and exit\n")
       cat("  --port, -p PORT      Specify the port (default: 8080)\n")
+      cat("  --host, -H HOST      Specify the host (default: 127.0.0.1)\n")
       cat("  --help, -h           Show this help message\n")
       quit(save = "no", status = 0)
     } else {
@@ -342,9 +351,9 @@ app <- list(
 )
 
 if (run_mode == "interactive" || run_mode == "background") {
-  cat("Starting R JSON server on port", port, "\n")
+  cat("Starting R JSON server on", host, "port", port, "\n")
   cat("Server PID:", Sys.getpid(), "\n")
-  server <<- startServer("127.0.0.1", port, app)
+  server <<- startServer(host, port, app)
   if (exists("tools::.signal_interruptible")) {
     tools::.signal_interruptible(2, function(sig) {
       cat("Received interrupt signal. Shutting down...\n")

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -1,6 +1,6 @@
 test_that("round-trip code returns expected result", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8123, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8123, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
   res <- replr::exec_code("1+1", port=8123, plain = FALSE, summary = TRUE)
@@ -13,7 +13,7 @@ test_that("plain text mode works", {
   ps <- processx::process$new(
     "Rscript",
     c(system.file("scripts", "replr_server.R", package = "replr"),
-      "--port", 8124, "--background")
+      "--port", 8124, "--host", "127.0.0.1", "--background")
   )
   on.exit(ps$kill())
   Sys.sleep(1)
@@ -27,7 +27,7 @@ test_that("explicit plain = FALSE returns JSON", {
   ps <- processx::process$new(
     "Rscript",
     c(system.file("scripts", "replr_server.R", package = "replr"),
-      "--port", 8128, "--background")
+      "--port", 8128, "--host", "127.0.0.1", "--background")
   )
   on.exit(ps$kill())
   Sys.sleep(1)
@@ -37,7 +37,7 @@ test_that("explicit plain = FALSE returns JSON", {
 
 test_that("warnings can be suppressed", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8125, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8125, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
   res <- replr::exec_code("warning('a'); 1", port=8125, warnings = FALSE,
@@ -47,7 +47,7 @@ test_that("warnings can be suppressed", {
 
 test_that("errors are captured correctly", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8126, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8126, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
   res <- replr::exec_code("log('foo')", port=8126, plain = FALSE, summary = TRUE)
@@ -57,7 +57,7 @@ test_that("errors are captured correctly", {
 
 test_that("full results are returned when requested", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8127, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8127, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
   res <- replr::exec_code("list(a = 1:3)", port = 8127, full_results = TRUE,

--- a/tests/testthat/test-preview-option.R
+++ b/tests/testthat/test-preview-option.R
@@ -1,6 +1,6 @@
 test_that("default preview_rows is 5", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8130, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8130, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
 
@@ -10,7 +10,7 @@ test_that("default preview_rows is 5", {
 
 test_that("preview_rows option can be changed", {
   skip_on_cran()
-  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8131, "--background"))
+  ps <- processx::process$new("Rscript", c(system.file("scripts", "replr_server.R", package="replr"), "--port", 8131, "--host", "127.0.0.1", "--background"))
   on.exit(ps$kill())
   Sys.sleep(1)
   replr::exec_code("options(replr.preview_rows=3)", port=8131, plain = FALSE)

--- a/tools/clir.ps1
+++ b/tools/clir.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = 'Stop'
 $configDir = Join-Path $HOME '.replr'
 $instFile  = Join-Path $configDir 'instances'
 $defaultPort = 8080
+$defaultHost = '127.0.0.1'
 
 if (!(Test-Path $configDir)) { New-Item -ItemType Directory -Path $configDir | Out-Null }
 if (!(Test-Path $instFile)) { New-Item -ItemType File -Path $instFile | Out-Null }
@@ -35,41 +36,49 @@ switch ($cmd) {
     'start' {
         $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
         $port  = if ($args.Length -gt 2) { [int]$args[2] } else { $defaultPort }
-        $proc = Start-Process -PassThru Rscript -ArgumentList 'replr_server.R','--background','--port',$port
+        $host  = if ($args.Length -gt 3) { $args[3] } else { $defaultHost }
+        $proc = Start-Process -PassThru Rscript -ArgumentList 'replr_server.R','--background','--port',$port,'--host',$host
         $inst[$label] = @{ port = $port; pid = $proc.Id }
         Save-Instances $inst
-        Write-Output "Started '$label' on port $port (PID $($proc.Id))"
+        Write-Output "Started '$label' on $host:$port (PID $($proc.Id))"
     }
     'stop' {
         $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
+        $host  = if ($args.Length -gt 2) { $args[2] } else { $defaultHost }
         $port = Port-Of $label $inst
-        Invoke-RestMethod -Uri "http://127.0.0.1:$port/shutdown" -Method Post > $null
+        Invoke-RestMethod -Uri "http://$host:$port/shutdown" -Method Post > $null
         if ($inst.ContainsKey($label)) { $inst.Remove($label); Save-Instances $inst }
-        Write-Output "Sent shutdown to '$label' (port $port)"
+        Write-Output "Sent shutdown to '$label' on $host (port $port)"
     }
     'status' {
         $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
         $json = $false
-        if ($args.Length -gt 2 -and $args[2] -eq '--json') { $json = $true }
+        $host = $defaultHost
+        $i = 2
+        while ($i -lt $args.Length) {
+            if ($args[$i] -eq '--json') { $json = $true; $i++ }
+            else { $host = $args[$i]; $i++ }
+        }
         $port = Port-Of $label $inst
-        $resp = Invoke-RestMethod -Uri "http://127.0.0.1:$port/status"
+        $resp = Invoke-RestMethod -Uri "http://$host:$port/status"
         if ($json) { $resp | ConvertTo-Json -Depth 10 } else { $resp }
     }
     'exec' {
         $label = if ($args.Length -gt 1) { $args[1] } else { 'default' }
         $code = $null
         $json = $false
+        $host = $defaultHost
         $i = 2
         while ($i -lt $args.Count) {
             if ($args[$i] -eq '-e') { $code = $args[$i+1]; $i += 2 }
             elseif ($args[$i] -eq '--json') { $json = $true; $i++ }
-            else { $i++ }
+            else { $host = $args[$i]; $i++ }
         }
         if (-not $code) { $code = [Console]::In.ReadToEnd() }
         if (-not $code) { Write-Error 'Nothing to run; supply code with -e or pipe via stdin'; exit 1 }
         $port = Port-Of $label $inst
         $body = @{ command = $code } | ConvertTo-Json
-        $url = "http://127.0.0.1:$port/execute"
+        $url = "http://$host:$port/execute"
         if (-not $json) { $url = "$url?format=text" } else { $url = "$url?plain=false" }
         $resp = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType 'application/json'
         if ($json) { $resp | ConvertTo-Json -Depth 10 } else { $resp }
@@ -78,6 +87,6 @@ switch ($cmd) {
         Get-Content $instFile
     }
     default {
-        Write-Output "Usage: clir.ps1 {start [label] [port]|stop [label]|status [label] [--json]|exec [label] [-e CODE] [--json]|exec [label] < script.R|list}"
+        Write-Output "Usage: clir.ps1 {start [label] [port] [host]|stop [label] [host]|status [label] [host] [--json]|exec [label] [-e CODE] [--json] [host]|list}"
     }
 }

--- a/tools/clir.py
+++ b/tools/clir.py
@@ -19,6 +19,7 @@ import requests
 CONFIG_DIR = os.path.expanduser("~/.replr")
 INST_FILE = os.path.join(CONFIG_DIR, "instances")
 DEFAULT_PORT = 8080
+DEFAULT_HOST = "127.0.0.1"
 
 
 def load_instances() -> Dict[str, Tuple[int, int]]:
@@ -48,7 +49,7 @@ def port_of(label: str, instances: Dict[str, Tuple[int, int]]) -> int:
         return DEFAULT_PORT
 
 
-def start(label: str, port: int) -> None:
+def start(label: str, port: int, host: str) -> None:
     inst = load_instances()
     proc = subprocess.Popen([
         "Rscript",
@@ -56,35 +57,37 @@ def start(label: str, port: int) -> None:
         "--background",
         "--port",
         str(port),
+        "--host",
+        host,
     ])
     inst[label] = (port, proc.pid)
     save_instances(inst)
-    print(f"Started '{label}' on port {port} (PID {proc.pid})")
+    print(f"Started '{label}' on {host}:{port} (PID {proc.pid})")
 
 
-def stop(label: str) -> None:
+def stop(label: str, host: str) -> None:
     inst = load_instances()
     port = port_of(label, inst)
     try:
-        requests.post(f"http://127.0.0.1:{port}/shutdown")
+        requests.post(f"http://{host}:{port}/shutdown")
     finally:
         if label in inst:
             inst.pop(label)
             save_instances(inst)
-    print(f"Sent shutdown to '{label}' (port {port})")
+    print(f"Sent shutdown to '{label}' on {host} (port {port})")
 
 
-def status(label: str, json_out: bool = False) -> None:
+def status(label: str, json_out: bool = False, host: str = DEFAULT_HOST) -> None:
     inst = load_instances()
     port = port_of(label, inst)
-    r = requests.get(f"http://127.0.0.1:{port}/status")
+    r = requests.get(f"http://{host}:{port}/status")
     if json_out:
         print(json.dumps(r.json(), indent=2))
     else:
         print(r.text)
 
 
-def exec_code(label: str, code: str | None, json_out: bool = False) -> None:
+def exec_code(label: str, code: str | None, json_out: bool = False, host: str = DEFAULT_HOST) -> None:
     inst = load_instances()
     port = port_of(label, inst)
     if not code:
@@ -93,7 +96,7 @@ def exec_code(label: str, code: str | None, json_out: bool = False) -> None:
             print("Nothing to run; supply code with -e or pipe via stdin", file=sys.stderr)
             sys.exit(1)
     def send() -> requests.Response:
-        url = f"http://127.0.0.1:{port}/execute"
+        url = f"http://{host}:{port}/execute"
         if not json_out:
             url += "?format=text"
         else:
@@ -103,8 +106,8 @@ def exec_code(label: str, code: str | None, json_out: bool = False) -> None:
     try:
         r = send()
     except requests.exceptions.ConnectionError:
-        print(f"Initializing server for '{label}' on port {port}...", file=sys.stderr)
-        start(label, port)
+        print(f"Initializing server for '{label}' on {host} port {port}...", file=sys.stderr)
+        start(label, port, host)
         time.sleep(1)
         r = send()
     if json_out:
@@ -126,31 +129,35 @@ def main() -> None:
     sp = sub.add_parser("start")
     sp.add_argument("label", nargs="?", default="default")
     sp.add_argument("port", nargs="?", type=int, default=DEFAULT_PORT)
+    sp.add_argument("host", nargs="?", default=DEFAULT_HOST)
 
     stop_p = sub.add_parser("stop")
     stop_p.add_argument("label", nargs="?", default="default")
+    stop_p.add_argument("host", nargs="?", default=DEFAULT_HOST)
 
     status_p = sub.add_parser("status")
     status_p.add_argument("label", nargs="?", default="default")
+    status_p.add_argument("host", nargs="?", default=DEFAULT_HOST)
     status_p.add_argument("--json", action="store_true")
 
     exec_p = sub.add_parser("exec")
     exec_p.add_argument("label", nargs="?", default="default")
     exec_p.add_argument("-e", dest="code")
     exec_p.add_argument("--json", action="store_true")
+    exec_p.add_argument("host", nargs="?", default=DEFAULT_HOST)
 
     sub.add_parser("list")
 
     args = parser.parse_args()
 
     if args.cmd == "start":
-        start(args.label, args.port)
+        start(args.label, args.port, args.host)
     elif args.cmd == "stop":
-        stop(args.label)
+        stop(args.label, args.host)
     elif args.cmd == "status":
-        status(args.label, args.json)
+        status(args.label, args.json, args.host)
     elif args.cmd == "exec":
-        exec_code(args.label, args.code, args.json)
+        exec_code(args.label, args.code, args.json, args.host)
     elif args.cmd == "list":
         list_instances()
     else:


### PR DESCRIPTION
## Summary
- allow `start_server()` and replr_server script to choose host
- pass host to CLI tools and update usage examples
- document host option in README and TOOL_GUIDE
- use host argument in tests

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_685483e86b3c8326a4e6499ccea7c1b3