### PR TITLE
Fix clir.py resource path and add CLI test

### DIFF
--- a/tests/testthat/test-python-cli.R
+++ b/tests/testthat/test-python-cli.R
@@ -1,0 +1,17 @@
+test_that("clir.py start works from another directory", {
+  skip_on_cran()
+  script <- normalizePath(file.path("..", "..", "tools", "clir.py"))
+  tmp <- tempfile("clirpy")
+  dir.create(tmp)
+  old <- getwd()
+  setwd(tmp)
+  on.exit({
+    setwd(old)
+    processx::run("python3", c(script, "stop", "clitest"), error_on_status = FALSE)
+  })
+  out <- processx::run("python3", c(script, "start", "clitest", "8140"), error_on_status = FALSE)
+  expect_equal(out$status, 0)
+  Sys.sleep(1)
+  st <- replr::server_status(8140)
+  expect_equal(st$status, "running")
+})

--- a/tools/clir.py
+++ b/tools/clir.py
@@ -12,7 +12,10 @@ import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Dict, Tuple
+
+from importlib import resources
 
 import requests
 
@@ -50,13 +53,22 @@ def port_of(label: str, instances: Dict[str, Tuple[int, int]]) -> int:
 
 def start(label: str, port: int) -> None:
     inst = load_instances()
-    proc = subprocess.Popen([
-        "Rscript",
-        "replr_server.R",
-        "--background",
-        "--port",
-        str(port),
-    ])
+    try:
+        script_path = resources.files("replr").joinpath("scripts", "replr_server.R")
+    except Exception:
+        script_path = Path(__file__).resolve().parent.parent / "inst" / "scripts" / "replr_server.R"
+    proc = subprocess.Popen(
+        [
+            "Rscript",
+            str(script_path),
+            "--background",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
     inst[label] = (port, proc.pid)
     save_instances(inst)
     print(f"Started '{label}' on port {port} (PID {proc.pid})")


### PR DESCRIPTION
## Summary
- locate `replr_server.R` using `importlib.resources` with a fallback
- detach background R server when starting from `clir.py`
- add regression test verifying `clir.py start` works from other dirs

## Testing
- `R CMD INSTALL .`
- `NOT_CRAN=true Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_685483a5171c832691e2c8520030f47f