### PR TITLE
Add R CMD check GitHub Action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,32 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yml
+          environment-name: myr
+          cache-environment: true
+          init-shell: bash
+      - name: R CMD check
+        run: |
+          R CMD build .
+          R CMD check --no-build-vignettes --no-manual $(ls -1t *.tar.gz | head -n 1)
+        shell: micromamba-shell {0}


### PR DESCRIPTION
## Summary
- add R CMD check workflow using r-lib template
- activate the `myr` environment via micromamba before running the check

## Testing
- `micromamba run -n myr R CMD check --no-build-vignettes --no-manual replr_0.0.1.tar.gz`

------
https://chatgpt.com/codex/tasks/task_e_68559eb4d260832696b64dadb0c0108f