### PR TITLE
Add rjson_response class return

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -13,7 +13,9 @@
 #'   full result object. This may produce large responses and expose sensitive
 #'   data.
 #' @return By default a character string of plain text. When `plain = FALSE` a
-#'   list representing the JSON response from the server is returned.
+#'   list representing the JSON response from the server is returned. The JSON
+#'   list has class `"rjson_response"` so methods like `as_tibble()` can
+#'   dispatch on it.
 #' @export
 exec_code <- function(code, port = 8080, plain = TRUE, summary = FALSE,
                       output = TRUE, warnings = TRUE, error = TRUE,
@@ -42,6 +44,7 @@ exec_code <- function(code, port = 8080, plain = TRUE, summary = FALSE,
   } else {
     out <- jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8"), simplifyVector = FALSE)
     if (!warnings) out$warning <- NULL
+    class(out) <- c("rjson_response", class(out))
     out
   }
 }

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Use `server_status()` to confirm the server is running, and `stop_server()` to s
 ### Returning full results
 
 `exec_code()` returns plain text by default. Set `plain = FALSE` to obtain a
-parsed JSON response. Use `summary = TRUE` or `full_results = TRUE` to request
-additional detail from the server.
+parsed JSON response. The returned list carries the class `"rjson_response"`,
+allowing helpers like `as_tibble()` to work. Use `summary = TRUE` or
+`full_results = TRUE` to request additional detail from the server.
 
 ### Controlling warnings and errors
 

--- a/tests/testthat/test-rjson-class.R
+++ b/tests/testthat/test-rjson-class.R
@@ -1,0 +1,12 @@
+test_that("exec_code returns rjson_response class", {
+  skip_on_cran()
+  ps <- processx::process$new(
+    "Rscript",
+    c(system.file("scripts", "replr_server.R", package = "replr"),
+      "--port", 8155, "--host", "127.0.0.1", "--background")
+  )
+  on.exit(ps$kill())
+  wait_for_server(8155)
+  res <- replr::exec_code("1+1", port = 8155, plain = FALSE, summary = TRUE)
+  expect_true("rjson_response" %in% class(res))
+})

--- a/vignettes/replr-usage.Rmd
+++ b/vignettes/replr-usage.Rmd
@@ -16,7 +16,8 @@ knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 
 `replr` provides a lightweight HTTP server that executes R code. By default the
 server returns the console text produced by the expression. Set `plain = FALSE`
-to receive structured JSON instead. This vignette demonstrates the core
+to receive structured JSON instead. The returned list has class
+`"rjson_response"`, enabling helper methods such as `as_tibble()`. This vignette demonstrates the core
 features for interacting with the server from R.
 
 # Starting and Stopping the Server


### PR DESCRIPTION
## Summary
- return `rjson_response`-class objects from `exec_code()` when requesting JSON
- document the new class in README and vignette
- add a test ensuring the new class is attached

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_68559ec438f48326944f67eac6726795