### PR TITLE
Add CITATION file and instructions

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,8 @@
+citHeader("To cite package 'replr' in publications use:")
+
+bibentry(
+  "Manual",
+  title = "replr: Local HTTP/JSON REPL for R",
+  author = person("Shane", "Lindsay", email = "shane.lindsay@gmail.com", role = c("aut", "cre")),
+  note = "R package version 0.0.1"
+)

--- a/README.md
+++ b/README.md
@@ -133,3 +133,13 @@ replr --command "1 + 1" --json
 data frame summaries is controlled by `replr.preview_rows` which defaults to `5`.
 Set this option before starting the server (or via `exec_code()` once running)
 to change how many rows are returned in previews.
+
+## Citing replr
+
+If you use **replr** in your work, please cite it. Run the following in R to get the citation information:
+
+```R
+citation("replr")
+```
+
+The output corresponds to the information stored in the `CITATION` file included with the package.


### PR DESCRIPTION
## Summary
- add a `CITATION` file based on `utils::citation('replr')`
- describe how to cite the package in the README

## Testing
- `testthat::test_dir('tests/testthat')`

------
https://chatgpt.com/codex/tasks/task_e_68559ecc679483269a65bbeff5b19047