### PR TITLE
Add CRAN release helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,13 @@ replr --command "1 + 1" --json
 data frame summaries is controlled by `replr.preview_rows` which defaults to `5`.
 Set this option before starting the server (or via `exec_code()` once running)
 to change how many rows are returned in previews.
+
+## Building and checking the package
+
+Use `tools/release_cran.R` to build a source tarball and run `R CMD check`.
+Ensure the `myr` environment is active so all dependencies are available.
+
+```bash
+micromamba activate myr
+Rscript tools/release_cran.R
+```

--- a/tools/release_cran.R
+++ b/tools/release_cran.R
@@ -1,0 +1,38 @@
+#!/usr/bin/env Rscript
+
+# Build the package and run R CMD check.
+
+# Determine repository root relative to this script
+args <- commandArgs(trailingOnly = FALSE)
+script_path <- sub("^--file=", "", args[grep("^--file=", args)])
+if (length(script_path) == 0) {
+  script_dir <- getwd()
+} else {
+  script_dir <- dirname(normalizePath(script_path))
+}
+repo_root <- normalizePath(file.path(script_dir, ".."))
+setwd(repo_root)
+
+# Read package metadata
+desc <- read.dcf("DESCRIPTION")
+package_name <- desc[1, "Package"]
+package_version <- desc[1, "Version"]
+
+# Build
+build_cmd <- c("CMD", "build", repo_root)
+status <- system2("R", build_cmd)
+if (status != 0) {
+  stop("R CMD build failed")
+}
+
+# Path to built tarball
+tarball <- sprintf("%s_%s.tar.gz", package_name, package_version)
+
+# Check
+check_cmd <- c("CMD", "check", tarball)
+status <- system2("R", check_cmd)
+if (status != 0) {
+  stop("R CMD check failed")
+}
+
+cat("Build and check completed successfully.\n")


### PR DESCRIPTION
## Summary
- add `tools/release_cran.R` for building and checking the package
- document the helper script in README

## Testing
- `R CMD build .`
- `R CMD check replr_0.0.1.tar.gz` *(fails: pdflatex not available)*

------
https://chatgpt.com/codex/tasks/task_e_68559ed0792c8326aeeac07f9fa0fe07